### PR TITLE
Comment Oracle 11 database version for EI-620 and EI-630

### DIFF
--- a/infra-test/wum-sce-test-wso2ei-6.2.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2ei-6.2.0-full-testgrid.yaml
@@ -11,7 +11,7 @@ infrastructureConfig:
      - CentOS-7.5
      - MySQL-5.6
      - MySQL-5.7
-     - Oracle-SE2-11.1
+  #   - Oracle-SE2-11.1
      - Oracle-SE2-12.1
      - SQLServer-SE-13.00
      - SQLServer-SE-14.00
@@ -47,4 +47,3 @@ scenarioConfigs:
     file: product-scenarios/test.sh
     inputParameters:
         ProductVersion: "EI-6.2.0"
-

--- a/infra-test/wum-sce-test-wso2ei-6.3.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2ei-6.3.0-full-testgrid.yaml
@@ -11,7 +11,7 @@ infrastructureConfig:
      - CentOS-7.5
      - MySQL-5.6
      - MySQL-5.7
-     - Oracle-SE2-11.1
+  #   - Oracle-SE2-11.1
      - Oracle-SE2-12.1
      - SQLServer-SE-13.00
      - SQLServer-SE-14.00


### PR DESCRIPTION
## Purpose
> Run tests without Oracle 11 database version.

## Goals
> Remove Oracle 11 database version from tets.

## Approach
> Comment the Oracle 11 database version from cloud formation template.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK Version : 8 , OS : Ubuntu 18/CentOS7, PostgreSQL 9.6/10.5, MSSQL 13.00/14.00, Oracle 12.1

## Learning
> N/A