### PR TITLE
Add ProductVersion input param

### DIFF
--- a/infra-test/wum-sce-test-wso2am-2.1.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.1.0-full-testgrid.yaml
@@ -42,3 +42,5 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.1.0"

--- a/infra-test/wum-sce-test-wso2am-2.2.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.2.0-full-testgrid.yaml
@@ -42,4 +42,6 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.2.0"
 

--- a/infra-test/wum-sce-test-wso2am-2.5.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.5.0-full-testgrid.yaml
@@ -42,4 +42,6 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.5.0"
 

--- a/infra-test/wum-sce-test-wso2am-2.6.0-full-postgres-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.6.0-full-postgres-testgrid.yaml
@@ -42,5 +42,7 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.6.0"
 
 

--- a/infra-test/wum-sce-test-wso2am-2.6.0-full-testgrid.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.6.0-full-testgrid.yaml
@@ -42,3 +42,5 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.6.0"

--- a/wum-dev-sce-devtest-wso2am-2.6.0-full-testgrid.yaml
+++ b/wum-dev-sce-devtest-wso2am-2.6.0-full-testgrid.yaml
@@ -34,4 +34,6 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios-devtest"
     file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.6.0"
 


### PR DESCRIPTION
## Purpose
APIM test cases expect ProductVersion property in deployment.properties file to identify the running deployment version. This property is then used to select the specific test suite that needs to run.