### PR TITLE
Add RemoteProductDir input parameter for apim 2.6.0 and 2.1.0

### DIFF
--- a/WUM/wum-sce-test-wso2am-2.1.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2am-2.1.0-full-testgrid.yaml
@@ -38,3 +38,5 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      RemoteProductDir: "/usr/lib/wso2/wso2am/2.1.0/wso2am-2.1.0"

--- a/WUM/wum-sce-test-wso2am-2.6.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2am-2.6.0-full-testgrid.yaml
@@ -37,4 +37,6 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
+    inputParameters:
+      RemoteProductDir: "/usr/lib/wso2/wso2am/2.6.0/wso2am-2.6.0"
 


### PR DESCRIPTION
## Purpose
> Define the Remote product directory path of the server side

## Goals
> Get the directory path to the deployment.properties file

## Approach
> Add a new input parameter
