### PR TITLE
Add RemoteProductDir input parameter for apim 2.6.0

### DIFF
--- a/wum-dev-sce-devtest-wso2am-2.6.0-full-testgrid.yaml
+++ b/wum-dev-sce-devtest-wso2am-2.6.0-full-testgrid.yaml
@@ -34,4 +34,6 @@ scenarioConfigs:
     name: "apim-scenarios"
     description: "apim-scenarios-devtest"
     file: product-scenarios/test.sh
+    inputParameters:
+      RemoteProductDir: "/usr/lib/wso2/wso2am/2.6.0/wso2am-2.6.0"
 


### PR DESCRIPTION
## Purpose
> Define the Remote product directory path of the server side

## Goals
> Get the directory path to the deployment.properties file

## Approach
> Add a new input parameter
