### PR TITLE
Add apim corretto test grid job for 2.6.0

### DIFF
--- a/team-apim/tanya-corretto-wso2am-2.6.0-full.yaml
+++ b/team-apim/tanya-corretto-wso2am-2.6.0-full.yaml
@@ -1,0 +1,39 @@
+# TestGrid Test Configuration Parameters
+version: '0.9'
+emailToList: "tanya@wso2.com"
+infrastructureConfig:
+  iacProvider: CLOUDFORMATION
+  infrastructureProvider: AWS
+  containerOrchestrationEngine: None
+  parameters:
+    - JDK : CORRETTO_JDK8
+  includes:
+     - Ubuntu-18.04
+     - MySQL-5.7
+     - CorrettoJDK-8
+  provisioners:
+    - name: two-node-deployment
+      remoteRepository: "git@github.com:TanyaM/aws-apim.git"
+      remoteBranch: "2.6.0"
+      description: Provision Infra for running scenario tests
+      scripts:
+        - name: 'prod-wso2-apim-scenario-deployment'
+          description: ''
+          type: CLOUDFORMATION
+          file: apim/Minimum-HA/apim.yaml
+          inputParameters:
+            parseInfrastructureScript: false
+            KeyPairName: "deployment-prod"
+            CertificateName: "wso2cert"
+            DBUsername: "wso2carbon"
+            DBPassword: "DB_Password"
+scenarioConfigs:
+  - testType: TESTNG
+    remoteRepository: "git@github.com:wso2/product-apim.git"
+    remoteBranch: "product-scenarios-dev"
+    name: "apim-scenarios"
+    description: "apim-scenarios-devtest"
+    file: product-scenarios/test.sh
+    inputParameters:
+      ProductVersion: "2.6.0"
+      RemoteProductDir: "/usr/lib/wso2/wso2am/2.6.0/wso2am-2.6.0"


### PR DESCRIPTION
## Purpose
There was no test grid job with Corretto JDK for apim distributed deployment.

## Goals
This PR adds the apim corretto test grid job.

## Approach
Inserted a new file called "tanya-corretto-wso2am-2.6.0-full.yaml" under "team-apim"