### PR TITLE
 Add centOs to apim 2.6 corretto test config

### DIFF
--- a/team-apim/tanya-corretto-wso2am-2.6.0-full.yaml
+++ b/team-apim/tanya-corretto-wso2am-2.6.0-full.yaml
@@ -9,6 +9,7 @@ infrastructureConfig:
     - JDK : CORRETTO_JDK8
   includes:
      - Ubuntu-18.04
+     - CentOS-7.5
      - MySQL-5.7
      - CorrettoJDK-8
   provisioners:


### PR DESCRIPTION
## Purpose
CentOS was missing in the Infrastructure combination of corretto test config. This PR adds that.

## Goals
Running scenario tests for CentOS, Corretto JDK and MySQL combination.

## Approach
Added CentOS to the infrastructure config.
