### PR TITLE
Update configurations for SUSE-Linux tests in APIM 2.6.0

### DIFF
--- a/infra-test/wum-sce-test-wso2am-2.6.0-full-testgrid-SUSE.yaml
+++ b/infra-test/wum-sce-test-wso2am-2.6.0-full-testgrid-SUSE.yaml
@@ -1,7 +1,7 @@
 # TestGrid job configuration
 
 version: '0.9'
-emailToList: "kosala@wso2.com,ching@wso2.com,kasung@wso2.com"
+emailToList: "kosala@wso2.com,ching@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS
@@ -23,15 +23,16 @@ infrastructureConfig:
           inputParameters:
             parseInfrastructureScript: false
             KeyPairName: "deployment-prod"
-            CertificateName: "wso2cert"
+            CertificateName: "wso2cert_us_east_2"
             DBUsername: "wso2carbon"
             DBPassword: "DB_Password"
+            region: "us-east-2"
 scenarioConfigs:
   - testType: TESTNG
     remoteRepository: "https://github.com/wso2/product-apim.git"
-    remoteBranch: "product-scenarios-dev"
+    remoteBranch: "product-scenarios"
     name: "apim-scenarios"
     description: "apim-scenarios"
     file: product-scenarios/test.sh
     inputParameters:
-      ProductVersion: "2.6.0"
+      RemoteProductDir: "/usr/lib/wso2/wso2am/2.6.0/wso2am-2.6.0"


### PR DESCRIPTION
## Purpose
> Add new configurations for SUSE Linux tests.

## Goals
> Use different repository and other configurations for APIM2.6.0 test with SUSE Linux. 
