### PR TITLE
Change JDK resource name

### DIFF
--- a/team-tg/kosala-tg-cost-optimization-tester.yaml
+++ b/team-tg/kosala-tg-cost-optimization-tester.yaml
@@ -31,17 +31,17 @@ jobConfig:
       combinations:
       - OS: Ubuntu-18.04
         DBEngine: MySQL-5.7
-        JDK: OPEN_JDK8
+        JDK: OpenJDK-8
     - schedule: daily
       combinationAlgorithm: exact
       combinations:
       - OS: CentOS-7.5
         DBEngine: MySQL-5.7
-        JDK: OPEN_JDK8
+        JDK: OpenJDK-8
         LDAP: Default
       - OS: Ubuntu-18.04
         DBEngine: MySQL-5.7
-        JDK: OPEN_JDK8
+        JDK: OpenJDK-8
         LDAP: Default
       - OS: Ubuntu-18.04
         DBEngine: MySQL-5.7
@@ -62,7 +62,7 @@ jobConfig:
           - Oracle-SE2-12.1
           - Postgres-10.5
       - JDK:
-          - OPEN_JDK8
+          - OpenJDK-8
           - OracleJDK-8
       - LDAP:
           - Default
@@ -77,7 +77,7 @@ jobConfig:
           - MySQL-5.6
           - Postgres-10.5
       - JDK:
-          - OPEN_JDK8
+          - OpenJDK-8
           - OracleJDK-8
       - LDAP:
           - Default


### PR DESCRIPTION
## Purpose
> Change JDK resource type due to database doe not contain the previously given name.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [x] Minor input parameter changes
- [ ] Other -> add a comment
<!-- 
- [x] Example ticked box -->

## Approach
> Change the Open JDK 8 infrastructure name from the yaml configuration file.