### PR TITLE
Adding Micro integrator docker yaml file

### DIFF
--- a/team-ei/dev_mi_docker.yaml
+++ b/team-ei/dev_mi_docker.yaml
@@ -1,0 +1,1 @@
+testgridYamlURL: https://raw.githubusercontent.com/RidmiR/testgrid-job-configs/mi_test/team-ei/ridmi_mi_docker.yaml


### PR DESCRIPTION
## Purpose
This yaml file contains the configurations to run the Micro integrator tests in a docker container. 

##Task
https://github.com/wso2/micro-integrator/issues/169
