### PR TITLE
Correct syntax for exposedDeployments

### DIFF
--- a/team-tg/wum-sce-test-helm-wso2am-2.6.0-new-charts.yaml
+++ b/team-tg/wum-sce-test-helm-wso2am-2.6.0-new-charts.yaml
@@ -33,7 +33,7 @@ deploymentConfig:
           type: HELM
           inputParameters:
             helmDeployScript: advanced/helm/testgrid-resources/deploy.sh
-            exposedDeployments: "'wso2am-pattern-1-am-1-deployment' 'wso2am-pattern-1-am-2-deployment' 'wso2am-pattern-1-analytics-worker-deployment'"
+            exposedDeployments: ["'wso2am-pattern-1-am-1-deployment' 'wso2am-pattern-1-am-2-deployment' 'wso2am-pattern-1-analytics-worker-deployment'"]
         - name: 'generate-deployment-properties-outputs'
           type: SHELL
           file: advanced/helm/testgrid-resources/setEndPoints.sh


### PR DESCRIPTION
## Purpose
> Correct erroneous syntax in job configuration yaml.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [x] Other -> syntax changed 
<!-- 
- [x] Example ticked box -->

NOTE:
For your job, you can either point to an external testgrid yaml configuration or keep the actual testgrid yaml here within this repo. Usually, people like to keep the testgrid yaml config within their own team repos because its easier to do changes.

You can point to an external testgrid yaml by having the job configration as follows:

$> cat [testgrid-job-configs/Ballerina/bbg-kafka.yaml](https://github.com/wso2/testgrid-job-configs/blob/ce9184d7e1c3719d74ad56325239f54bff21e18b/Ballerina/bbg-kafka.yaml)
```
testgridYamlURL: https://raw.githubusercontent.com/ballerina-platform/ballerina-scenario-tests/scenario-tests/.testgrid-bbg-kafka.yaml

```
More details can be found in user guide - https://docs.google.com/document/d/1fYCUg97VsfoftEo1HfPWjdS6whp4r0noGRzfaxsxmek/edit#

