### PR TITLE
Add integration-builder mailing list to integration jobs

### DIFF
--- a/WUM/wum-sce-test-wso2ei-6.1.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.1.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2ei-6.1.1-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.1.1-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2ei-6.2.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.2.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2ei-6.3.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.3.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2ei-6.4.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.4.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,
-              isuruuy@wso2.com,ridmi@wso2.com,kasuna@wso2.com,kasung@wso2.com"
+              isuruuy@wso2.com,ridmi@wso2.com,kasuna@wso2.com,kasung@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2ei-6.5.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.5.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2esb-4.9.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2esb-4.9.0-full-testgrid.yaml
@@ -2,7 +2,7 @@
 
 version: '0.9'
 emailToList: "builder@wso2.org,kasung@wso2.com,chaminda@wso2.com,isuruu@wso2.com,nandika@wso2.com,
-              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com"
+              milindap@wso2.com,dulanjali@wso2.com,sasikala@wso2.com,isuruuy@wso2.com,ridmi@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2esb-5.0.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2esb-5.0.0-full-testgrid.yaml
@@ -1,7 +1,7 @@
 # TestGrid job configuration
 
 version: '0.9'
-emailToList: "builder@wso2.org,kasung@wso2.com,dulanjali@wso2.com"
+emailToList: "builder@wso2.org,kasung@wso2.com,dulanjali@wso2.com,integration-builder@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS


### PR DESCRIPTION
## Purpose
Currently testgrid job mails are sent only to selected people. Hence, adding the newly created mailing list to the config so the people in the operations team can monitor the builds.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [x] Other -> Added a new recipient mail to the current Integration build configs.
<!-- 
- [x] Example ticked box -->

NOTE 1:
Current repo owners: @msmshariq, @ThilinaManamgoda, @VimukthiPerera, @chamithkumarage, @kasunbg
Ex repo owners: @yasassri, @sameerawickramasekara, @azinneera, @pasindujw

NOTE 2:
For your job, you can either point to an external testgrid yaml configuration or keep the actual testgrid yaml here within this repo. Usually, people like to keep the testgrid yaml config within their own team repos because its easier to do changes.

You can point to an external testgrid yaml by having the job configration as follows:

$> cat [testgrid-job-configs/Ballerina/bbg-kafka.yaml](https://github.com/wso2/testgrid-job-configs/blob/ce9184d7e1c3719d74ad56325239f54bff21e18b/Ballerina/bbg-kafka.yaml)
```
testgridYamlURL: https://raw.githubusercontent.com/ballerina-platform/ballerina-scenario-tests/scenario-tests/.testgrid-bbg-kafka.yaml

```
More details can be found in user guide - https://docs.google.com/document/d/1fYCUg97VsfoftEo1HfPWjdS6whp4r0noGRzfaxsxmek/edit#

