### PR TITLE
Add new perf apim-2.6.0 with two jmeter servers

### DIFF
--- a/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
+++ b/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
@@ -31,7 +31,7 @@ infrastructureConfig:
             JmeterClientInstanceType: "t3.small"
             JmeterServerInstanceType: "t3.small"
             # Please use 2 Jmeter-servers if concurrency > 500 users
-            NumberOfJmeterServers: 2
+            NumberOfJMeterServers: "2"
 scenarioConfigs:
   - testType: JMETER
     remoteRepository: "git@github.com:janethavi/performance-apim.git"

--- a/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
+++ b/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
@@ -1,0 +1,51 @@
+version: '0.9'
+emailToList: "janeth@wso2.com"
+infrastructureConfig:
+  iacProvider: CLOUDFORMATION
+  infrastructureProvider: AWS
+  containerOrchestrationEngine: None
+  includes:
+    - Ubuntu-18.04
+    - MySQL-5.7
+    - ORACLE_JDK8
+  provisioners:
+    - name: single-node-deployment
+      remoteRepository: "git@github.com:janethavi/aws-apim.git"
+      remoteBranch: "performance-testgrid"
+      description: Provision Infra for running scenario tests
+      scripts:
+        # Deployment of apim pattern-1 + JMeter
+        - name: 'prod-wso2-apim-perf-deployment'
+          description: ''
+          type: CLOUDFORMATION
+          file: jmeter-deployment-nested.yaml
+          inputParameters:
+            ProductDeploymentURL: "https://performance-test-archives.s3.us-east-2.amazonaws.com/pattern-1.yaml"
+            ProductInstanceType: "t2.medium"
+            ProductDBType: "db.t2.medium"
+            CertificateName: "self-signed-cert"
+            DBUsername: "wso2carbon"
+            DBPassword: "DB_Password"
+            region: "us-east-2"
+            BackendInstanceType: "t3.small"
+            JmeterClientInstanceType: "t3.small"
+            JmeterServerInstanceType: "t3.small"
+            # Please use 2 Jmeter-servers if concurrency > 500 users
+            NumberOfJmeterServers: 2
+scenarioConfigs:
+  - testType: JMETER
+    remoteRepository: "git@github.com:janethavi/performance-apim.git"
+    remoteBranch: "test-grid"
+    name: "apim-perf-test"
+    description: "apim-scenarios"
+    file: distribution/scripts/scenario-test.sh
+    inputParameters:
+      heap_memory_app: 1G
+      con_users: "500,600"
+      msg_size: "50,1024"
+      backend_sleep: 0
+      test_duration: 120
+      warmup_time: 60
+      heap_memory_jmeter_s: 512M
+      heap_memory_jmeter_c: 512M
+      heap_memory_netty: 515M

--- a/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
+++ b/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
@@ -21,17 +21,17 @@ infrastructureConfig:
           file: jmeter-deployment-nested.yaml
           inputParameters:
             ProductDeploymentURL: "https://performance-test-archives.s3.us-east-2.amazonaws.com/pattern-1.yaml"
-            ProductInstanceType: "t2.medium"
-            ProductDBType: "db.t2.medium"
+            ProductInstanceType: "c5.large"
+            ProductDBType: "db.m5.large"
             CertificateName: "self-signed-cert"
             DBUsername: "wso2carbon"
             DBPassword: "DB_Password"
             region: "us-east-2"
-            BackendInstanceType: "t3.small"
-            JmeterClientInstanceType: "t3.small"
-            JmeterServerInstanceType: "t3.small"
+            BackendInstanceType: "c5.xlarge"
+            JmeterClientInstanceType: "c5.large"
+            JmeterServerInstanceType: "c5.large"
             # Please use 2 Jmeter-servers if concurrency > 500 users
-            NumberOfJMeterServers: 2
+            NumberOfJMeterServers: "2"
 scenarioConfigs:
   - testType: JMETER
     remoteRepository: "git@github.com:janethavi/performance-apim.git"
@@ -40,12 +40,12 @@ scenarioConfigs:
     description: "apim-scenarios"
     file: distribution/scripts/scenario-test.sh
     inputParameters:
-      heap_memory_app: 1G
-      con_users: "500,600"
+      heap_memory_app: 2G
+      con_users: "100,250,500,750,1000"
       msg_size: "50,1024"
       backend_sleep: 0
-      test_duration: 120
-      warmup_time: 60
-      heap_memory_jmeter_s: 512M
-      heap_memory_jmeter_c: 512M
-      heap_memory_netty: 515M
+      test_duration: 360
+      warmup_time: 180
+      heap_memory_jmeter_s: 2G
+      heap_memory_jmeter_c: 2G
+      heap_memory_netty: 2G

--- a/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
+++ b/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml
@@ -31,7 +31,7 @@ infrastructureConfig:
             JmeterClientInstanceType: "t3.small"
             JmeterServerInstanceType: "t3.small"
             # Please use 2 Jmeter-servers if concurrency > 500 users
-            NumberOfJMeterServers: "2"
+            NumberOfJMeterServers: 2
 scenarioConfigs:
   - testType: JMETER
     remoteRepository: "git@github.com:janethavi/performance-apim.git"


### PR DESCRIPTION
## Purpose
> Added a new job to do performance test of APIM 2.6.0 (with 2 JMeter servers)

## Task performed
- [x] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment