### PR TITLE
Add new job for perf-apim-2.6.0

### DIFF
--- a/team-tg/janeth-perf-apim-2.6.0-two-jmeter-servers.yaml
+++ b/team-tg/janeth-perf-apim-2.6.0-two-jmeter-servers.yaml
@@ -1,0 +1,1 @@
+testgridYamlURL: https://raw.githubusercontent.com/janethavi/testgrid-job-configs/jmeter-servers/team-tg/janeth-perf-with-jmeter-servers-apim-2.6.0.yaml


### PR DESCRIPTION
## Purpose
> Add a new job for apim-2.6.0 pattern-1 performance testing with two JMeter servers.

## Task performed
- [x] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment