### PR TITLE
Change RemoteProductDir of EI 6.6.0 job

### DIFF
--- a/WUM/wum-sce-test-wso2ei-6.6.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ei-6.6.0-full-testgrid.yaml
@@ -58,4 +58,4 @@ scenarioConfigs:
     file: product-scenarios/test.sh
     inputParameters:
       ProductVersion: "EI-6.6.0"
-      RemoteProductDir: "/usr/local/wso2/wso2ei/6.6.0/wso2ei-6.6.0"
+      RemoteProductDir: "/usr/lib/wso2/wso2ei/6.6.0/wso2ei-6.6.0"


### PR DESCRIPTION
## Purpose
Change RemoteProductDir of EI 6.6.0 job.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [x] Minor input parameter changes
- [ ] Other -> add a comment
<!-- 
- [x] Example ticked box -->

NOTE 1:
Current repo owners: @msmshariq, @ThilinaManamgoda, @VimukthiPerera, @chamithkumarage, @kasunbg
Ex repo owners: @yasassri, @sameerawickramasekara, @azinneera, @pasindujw

NOTE 2:
For your job, you can either point to an external testgrid yaml configuration or keep the actual testgrid yaml here within this repo. Usually, people like to keep the testgrid yaml config within their own team repos because its easier to do changes.

You can point to an external testgrid yaml by having the job configration as follows:

$> cat [testgrid-job-configs/Ballerina/bbg-kafka.yaml](https://github.com/wso2/testgrid-job-configs/blob/ce9184d7e1c3719d74ad56325239f54bff21e18b/Ballerina/bbg-kafka.yaml)
```
testgridYamlURL: https://raw.githubusercontent.com/ballerina-platform/ballerina-scenario-tests/scenario-tests/.testgrid-bbg-kafka.yaml

```
More details can be found in user guide - https://docs.google.com/document/d/1fYCUg97VsfoftEo1HfPWjdS6whp4r0noGRzfaxsxmek/edit#

