### PR TITLE
Config MariaDB as a infrastructure value

### DIFF
--- a/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
@@ -3,7 +3,7 @@
 version: '0.9'
 emailToList: "builder@wso2.org,shanikaw@wso2.com,niluka@wso2.com,achinij@wso2.com,
                            kanapriya@wso2.com,iam-builder@wso2.com,integration-builder@wso2.com,
-                           ashen@wso2.com,jayangak@wso2.com,buddhimau@wso2.com"
+                           ashen@wso2.com,jayangak@wso2.com,buddhimau@wso2.com,ridmi@wso2.com"
 infrastructureConfig:
   iacProvider: CLOUDFORMATION
   infrastructureProvider: AWS

--- a/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
@@ -11,6 +11,7 @@ infrastructureConfig:
   includes:
     - CentOS-7.5
     - MySQL-5.7
+    - MariaDB-10.4
     - Oracle-SE2-12.1
     - SQLServer-SE-14.00
     - Postgres-10.5


### PR DESCRIPTION
## Purpose
Config MariaDB in infrastructure Config to run the scenario tests with MariaDB + MariaDB Driver for IS 5.11.0

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [x] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment

## User stories
wso2/product-is#10264





