### PR TITLE
Add MySQL 8 as a DB version for IS 5.11.0

### DIFF
--- a/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2is-latest-jenkins-build-testgrid.yaml
@@ -10,7 +10,7 @@ infrastructureConfig:
   containerOrchestrationEngine: None
   includes:
     - CentOS-7.5
-    - MySQL-5.7
+    - MySQL-8.0
     - MariaDB-10.4
     - Oracle-SE2-12.1
     - SQLServer-SE-14.00


### PR DESCRIPTION
## Purpose
Update the scenario test job config to test the compatibility with SI 5.11.0 for MySQL 8 DB version.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [x] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment

## Relates Issues
https://github.com/wso2/product-is/issues/9781
