### PR TITLE
Add Postgres-12.3 as a infrastructure value to test compatibility with IS 5.10

### DIFF
--- a/WUM/wum-sce-test-wso2is-5.10.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2is-5.10.0-full-testgrid.yaml
@@ -14,6 +14,7 @@ infrastructureConfig:
     - Oracle-SE2-12.1
     - SQLServer-SE-14.00
     - Postgres-10.5
+    - Postgres-12.3
     - ADOPT_OPEN_JDK11
   provisioners:
     - name: two-node-deployment


### PR DESCRIPTION
## Purpose
There is a customer request for  IS 5.10 compatibility with Postgres-12.3. This PR includes the change for the job config in order to run the 5.10 scenario tests.

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [x] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [ ] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment
