### PR TITLE
[OB][Test-Grid] Add BrowserAutomation.BrowserPreference to OB inputParameters

### DIFF
--- a/Staging-Updates-2.0/u2-sce-test-wso2ob-1.5.0-staging-testgrid.yaml
+++ b/Staging-Updates-2.0/u2-sce-test-wso2ob-1.5.0-staging-testgrid.yaml
@@ -44,4 +44,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.5"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/Staging-Updates-2.0/u2-sce-test-wso2ob-1.5.0-staging-testgrid.yaml
+++ b/Staging-Updates-2.0/u2-sce-test-wso2ob-1.5.0-staging-testgrid.yaml
@@ -44,3 +44,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.5"
+      BrowserAutomation.BrowserPreference: firefox

--- a/Staging-Updates-2.0/u2-sce-test-wso2ob-2.0.0-staging-testgrid.yaml
+++ b/Staging-Updates-2.0/u2-sce-test-wso2ob-2.0.0-staging-testgrid.yaml
@@ -43,4 +43,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.5"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/Staging-Updates-2.0/u2-sce-test-wso2ob-2.0.0-staging-testgrid.yaml
+++ b/Staging-Updates-2.0/u2-sce-test-wso2ob-2.0.0-staging-testgrid.yaml
@@ -43,3 +43,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.5"
+      BrowserAutomation.BrowserPreference: firefox

--- a/Updates-2.0/u2-sce-test-wso2ob-1.5.0-full-testgrid.yaml
+++ b/Updates-2.0/u2-sce-test-wso2ob-1.5.0-full-testgrid.yaml
@@ -44,4 +44,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/Updates-2.0/u2-sce-test-wso2ob-1.5.0-full-testgrid.yaml
+++ b/Updates-2.0/u2-sce-test-wso2ob-1.5.0-full-testgrid.yaml
@@ -44,3 +44,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
+      BrowserAutomation.BrowserPreference: firefox

--- a/Updates-2.0/u2-sce-test-wso2ob-2.0.0-full-testgrid.yaml
+++ b/Updates-2.0/u2-sce-test-wso2ob-2.0.0-full-testgrid.yaml
@@ -43,4 +43,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/Updates-2.0/u2-sce-test-wso2ob-2.0.0-full-testgrid.yaml
+++ b/Updates-2.0/u2-sce-test-wso2ob-2.0.0-full-testgrid.yaml
@@ -43,3 +43,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
+      BrowserAutomation.BrowserPreference: firefox

--- a/WUM/wum-sce-test-wso2ob-1.3.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.3.0-full-testgrid.yaml
@@ -42,3 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
+      BrowserAutomation.BrowserPreference: firefox

--- a/WUM/wum-sce-test-wso2ob-1.3.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.3.0-full-testgrid.yaml
@@ -42,4 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/WUM/wum-sce-test-wso2ob-1.4.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.4.0-full-testgrid.yaml
@@ -42,3 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
+      BrowserAutomation.BrowserPreference: firefox

--- a/WUM/wum-sce-test-wso2ob-1.4.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.4.0-full-testgrid.yaml
@@ -42,4 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"

--- a/WUM/wum-sce-test-wso2ob-1.5.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.5.0-full-testgrid.yaml
@@ -42,3 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
+      BrowserAutomation.BrowserPreference: firefox

--- a/WUM/wum-sce-test-wso2ob-1.5.0-full-testgrid.yaml
+++ b/WUM/wum-sce-test-wso2ob-1.5.0-full-testgrid.yaml
@@ -42,4 +42,4 @@ scenarioConfigs:
       BrowserAutomation.HeadlessEnabled: true
       InstallGeckodriver: true
       ApiVersion: "3.1.1"
-      BrowserAutomation.BrowserPreference: firefox
+      BrowserAutomation.BrowserPreference: "firefox"


### PR DESCRIPTION
## Purpose
> This PR will add BrowserAutomation.BrowserPreference to OB inputParameteres. The purpose is to run either Firefox or Chrome browser for test automation depending on the user preference. The default value is set to firefox

## Task performed
- [ ] Added a new job
- [ ] Removed a job -> inform tg folks to clean the dashboard
- [ ] Added new infrastructure value
- [ ] Commented out an infrastructure value
- [ ] Added new infrastructure provisioner
- [X] Added new test config
- [ ] Minor input parameter changes
- [ ] Other -> add a comment
<!-- 
- [x] Example ticked box -->

NOTE 1:
Current repo owners: @msmshariq, @ThilinaManamgoda, @VimukthiPerera, @chamithkumarage, @kasunbg
Ex repo owners: @yasassri, @sameerawickramasekara, @azinneera, @pasindujw

NOTE 2:
For your job, you can either point to an external testgrid yaml configuration or keep the actual testgrid yaml here within this repo. Usually, people like to keep the testgrid yaml config within their own team repos because its easier to do changes.

You can point to an external testgrid yaml by having the job configration as follows:

$> cat [testgrid-job-configs/Ballerina/bbg-kafka.yaml](https://github.com/wso2/testgrid-job-configs/blob/ce9184d7e1c3719d74ad56325239f54bff21e18b/Ballerina/bbg-kafka.yaml)
```
testgridYamlURL: https://raw.githubusercontent.com/ballerina-platform/ballerina-scenario-tests/scenario-tests/.testgrid-bbg-kafka.yaml

```
More details can be found in user guide - https://docs.google.com/document/d/1fYCUg97VsfoftEo1HfPWjdS6whp4r0noGRzfaxsxmek/edit#

